### PR TITLE
外部リソースに対して更新をかけるワークフローの同時実行数を1にする

### DIFF
--- a/.github/workflows/runner-info.yml
+++ b/.github/workflows/runner-info.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on:
       - ubuntu-latest
 
+    concurrency:
+      group: ${{ github.action }}
+      cancel-in-progress: true
+
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v3


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency